### PR TITLE
fix: fix min height in section

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -14,7 +14,7 @@
         <h4>Key Retriever</h4>
       </div>
     </header>
-    <section class="mt-1">
+    <section class="mt-1" style="min-height: 5em">
       <div
         id="emptyPage"
         class="flex flex-col align-items-center my-3 display-none"


### PR DESCRIPTION
This PR adds a min height to section to ensure when opening more actions menu (and having only one key defined), the extension does not do a "progressive height increase" behaviour.

# Screenshots

## Only one key defined:
<img width="400" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/13af0bb1-0756-4318-8abc-381f3ddb7f18">

## Only one key defined with more actions menu open:
<img width="400" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/cbf255e0-af09-4585-8d36-db65d7b8fb19">

