### PR TITLE
fix: remove placeholders and add required flag to labels

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -55,9 +55,3 @@ header {
   background-color: var(--dark-gray);
   border-color: var(--dark-gray);
 }
-
-.form-floating > .form-control:focus {
-  &::placeholder {
-    color: var(--light-gray) !important;
-  }
-}

--- a/src/popup.html
+++ b/src/popup.html
@@ -74,17 +74,17 @@
             </div>
           </div>
           <div class="form-floating mb-3">
-            <input id="key" type="text" class="form-control" name="key" placeholder="e.g. SSID" required />
-            <label for="key" class="form-label">Key</label>
+            <input id="key" type="text" class="form-control" name="key" required value="" />
+            <label for="key" class="form-label">Key <span style="color: red">*</span></label>
             <div class="invalid-feedback">Please choose a key.</div>
           </div>
           <div class="form-floating mb-3">
-            <input id="subKey" type="text" class="form-control" name="subKey" placeholder="e.g. cachedValue" />
+            <input id="subKey" type="text" class="form-control" name="subKey" />
             <label for="subKey" class="form-label">Sub-key</label>
           </div>
           <div class="form-floating mb-3">
-            <input id="alias" type="text" class="form-control" name="alias" placeholder="e.g. Auth token" required />
-            <label for="alias" class="form-label">Alias</label>
+            <input id="alias" type="text" class="form-control" name="alias" required />
+            <label for="alias" class="form-label">Alias <span style="color: red">*</span></label>
             <div class="invalid-feedback">Please choose an alias for your key.</div>
           </div>
         </form>


### PR DESCRIPTION
This PR removes placeholders of fields in add key form. 

**Reason**: This change was needed due to an incompatibility behavior of bootstrap with floating labels + placeholders. Basically, enabling placeholders (like we did) would make the label look like a value and only would show a placeholder when the input was focused. We tried some workarounds but none met our expectations of how these floating labels should work - we wanted something like material ui behaviour:

<img width="253" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/f028557d-9dfb-4f09-afc5-e2bba42515dd">

Also see: https://github.com/twbs/bootstrap/issues/33999

Additionally, a red * was added to required fields in add key form.

## Add key form:
<img width="398" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/df2f602d-df4e-4bc0-93ef-eadcbeffb35d">

