### PR TITLE
fix: fix scroll to section

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -7,19 +7,25 @@
   --green: #198754;
 }
 
-html {
-  max-height: 10em;
-  min-width: 25em;
-  overflow-y: scroll;
-}
-
 body {
+  min-width: 25em;
   padding: 1em;
+  overflow: hidden;
 }
 
 header {
   padding: 0.4em;
   color: var(--dark-gray);
+}
+
+section {
+  max-height: 28em;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+section:has(.dropdown-menu.show) {
+  min-height: 10em;
 }
 
 .display-none {

--- a/src/popup.html
+++ b/src/popup.html
@@ -13,7 +13,7 @@
           <img src="../images/icon48.png" width="48" height="48" class="me-3" />
           <h4>Key Retriever</h4>
         </div>
-        <button id="refreshBtn" type="button" class="btn" style="color: var(--green);">
+        <button id="refreshBtn" type="button" class="btn" style="color: var(--green)">
           <i class="fa-solid fa-arrows-rotate fa-lg"></i>
         </button>
       </div>
@@ -34,7 +34,7 @@
         <button type="button" class="btn-close ms-2" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     </header>
-    <section class="mt-1" style="min-height: 5em">
+    <section class="mt-1">
       <div id="emptyPage" class="flex flex-col align-items-center my-3 display-none">
         <img class="mb-4" src="../images/empty-page.jpg" width="200" height="75" />
         <em style="color: var(--medium-gray)">Key retriever is waiting for your new keys</em>


### PR DESCRIPTION
This PR adds a scroll only to section. Also, it was added a tweak to dropdown menu min height when 1 or 2 options were defined, in order to accommodate dropdown menu without scroll.

# Screenshots

## Scroll in section
<img width="397" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/6aa8cc66-d81f-4d6f-921b-78d930ba43af">

## Tweak for dropdown menu
<img width="397" alt="image" src="https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/29409357/59a2fe32-196a-48c4-97e5-7e4c9a1624af">
