### PR TITLE
add domain to add item

### DIFF
--- a/src/handler/operation/cookie.js
+++ b/src/handler/operation/cookie.js
@@ -22,9 +22,9 @@ async function getCookie(tab, cookieStoreItems) {
   });
 }
 
-async function saveCookieValue(tab, key, subKey, value) {
+async function saveCookieValue(tab, key, subKey, userDomain, value) {
   const url = tabToStringUrl(tab);
-  const domain = tabToStringDomain(tab);
+  const domain =   tabToStringDomain(userDomain|| url);
   let details = await chrome.cookies.get({
     name: key,
     url,
@@ -68,8 +68,8 @@ function tabToStringUrl(tab) {
   return `${url.protocol}//${url.hostname}`;
 }
 
-function tabToStringDomain(tab) {
-  const url = new URL(tab.url);
+function tabToStringDomain(inputUrl) {
+  const url = new URL(inputUrl.startsWith("http") ? inputUrl : `http://${inputUrl}`);
   return `.${url.hostname}`;
 }
 

--- a/src/handler/valueWriter.js
+++ b/src/handler/valueWriter.js
@@ -23,9 +23,9 @@ async function saveLocalValue(tab, key, subKey = "", value) {
   return false;
 }
 
-async function saveCookieValue(tab, key, subKey = "", value) {
+async function saveCookieValue(tab, key, subKey = "", domain, value) {
   try {
-    return await chromeSaveCookieValue(tab, key, subKey, value);
+    return await chromeSaveCookieValue(tab, key, subKey, domain, value);
   } catch (e) {
     console.log("🐶 ~ could not set cookie value for key " + key + " :", e);
   }

--- a/src/manager.js
+++ b/src/manager.js
@@ -39,7 +39,7 @@ function appManager() {
       case TYPES.LOCAL:
         return saveLocalValue(tab, item.key, item.subKey, value);
       case TYPES.COOKIE:
-        return saveCookieValue(tab, item.key, item.subKey, value);
+        return saveCookieValue(tab, item.key, item.subKey, item.domain, value);
     }
 
     return false;

--- a/src/page.js
+++ b/src/page.js
@@ -53,6 +53,16 @@ function appPage({ storeSave, storeDelete, storeSet, refreshValues }) {
     show(PAGES.LIST);
   });
 
+  document.querySelectorAll('input[name="storage"]').forEach((input) =>
+    input.addEventListener("click", (e) => {
+      const domainField = document.getElementById("domainField");
+
+      if (e.target.id === "localStorage" || e.target.id === "sessionStorage") {
+        if (!domainField.classList.contains("display-none")) domainField.classList.add("display-none");
+      } else domainField.classList.remove("display-none");
+    }),
+  );
+
   function show(page) {
     const emptyPage = document.getElementById("emptyPage");
     const addKeyForm = document.getElementById("addKeyForm");
@@ -233,15 +243,17 @@ function appPage({ storeSave, storeDelete, storeSet, refreshValues }) {
     const alias = document.getElementById("alias").value;
     const key = document.getElementById("key").value;
     const subKey = document.getElementById("subKey").value || undefined;
+    const domain = document.getElementById("domain").value || undefined;
     const storageType = document.querySelector('input[name="storage"]:checked').value;
 
-    return { alias, key, subKey, type: storageType };
+    return { alias, key, subKey, domain, type: storageType };
   }
 
   function clearFormData() {
     document.getElementById("alias").value = "";
     document.getElementById("key").value = "";
     document.getElementById("subKey").value = "";
+    document.getElementById("domain").value = "";
     document.querySelector('input[name="storage"]').checked = false;
     document.querySelector('input[id="sessionStorage"]').checked = true;
   }

--- a/src/popup.html
+++ b/src/popup.html
@@ -78,6 +78,10 @@
               </div>
             </div>
           </div>
+          <div id="domainField" class="form-floating mb-3 display-none">
+            <input id="domain" type="text" class="form-control" name="domain" />
+            <label for="domain" class="form-label">Domain</label>
+          </div>
           <div class="form-floating mb-3">
             <input id="key" type="text" class="form-control" name="key" required value="" />
             <label for="key" class="form-label">Key <span style="color: red">*</span></label>

--- a/src/view/items.js
+++ b/src/view/items.js
@@ -43,7 +43,7 @@ function newItem({ storageType, item, actions }) {
     return [{ action: copyButton, visible: false }, { action: moreActionsButton }];
   }
 
-  function itemFooter({ id, key, subKey }) {
+  function itemFooter({ id, domain, key, subKey }) {
     const footerBody = document.createElement("div");
     addClassesToElement(footerBody, "flex flex-col mb-2");
 
@@ -57,6 +57,11 @@ function newItem({ storageType, item, actions }) {
     if (subKey) {
       const subKeyLabel = newLabelWithBadge({ label: "Subkey", value: subKey || "" });
       keyDetailsArea.appendChild(subKeyLabel);
+    }
+
+    if (domain) {
+      const domainLabel = newLabelWithBadge({ label: "Domain", value: domain || "" });
+      keyDetailsArea.appendChild(domainLabel);
     }
 
     footerBody.appendChild(keyDetailsArea);


### PR DESCRIPTION
Add domain field when creating a new cookie item.

# Important
## GET
If there are multiples match to a key, it will select based on the order that the browser sent it.
This is not a new behavior, but would be interesting to figure out how is the order affected.
## SET
> Retrieves information about a single cookie. If more than one cookie of the same name exists for the given URL, the one with the longest path will be returned. For cookies with the same path length, the cookie with the earliest creation time will be returned.
https://developer.chrome.com/docs/extensions/reference/cookies/#method-get

What this is actually saying is even if we request a cookie for a subdomain (subdomain.domain.com) if there are collisions with a same name cookie in the domain (domain.com) it will pick the most recent.

I'm unsure if we should retrieve all the cookies and select the correct subdomain cookie, or if this is a non issue.

Should we dig deeper?


## screenshots

### create page
![image](https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/12955328/984d1109-d741-405d-9558-3f466242bc00)

### view page
![image](https://github.com/Room-Elephant/extension-chrome-key-retriever/assets/12955328/7d2aaea0-0a5d-4185-b3d1-6fe794f43ea8)
